### PR TITLE
Add Default Install For RHDH Operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@ This helm chart installs and configures the following operators:
 
 |       Product       |      Installation       |                                                                                                      Configuration                                                                                                       |
 | :-----------------: | :---------------------: | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
-|  OpenShift GitOps   | Operator `Subscription` |                                    Controlled by the values YAML file. If a subscription already exists, the installation will not modify it. A new instance ArgoCD will be created.                                     |
+|  OpenShift GitOps   | Operator `Subscription` |                                    Controlled by the values YAML file. If a subscription already exists, the installation will not modify it. A new instance of ArgoCD will be created.                                     |
 | OpenShift Pipelines | Operator `Subscription` | Controlled by the values YAML file. If a subscription already exists, the installation will not modify it. In all cases, the TektonConfig will be modified to enable Tekton Chains and the signing secret will be setup. |
+| Red Hat Developer Hub | Operator `Subscription` | Controlled by the values YAML file. If a subscription already exists, the installation will not modify it. A new instance of RHDH will be created. |
 
 **Note**: If a subscription for an operator already exists, the installation will not tamper with it.
 

--- a/README.md
+++ b/README.md
@@ -26,15 +26,19 @@ This helm chart installs and configures the following operators:
 
 ### Install
 
-Run `helm upgrade --install <release-name> <path-to-chart>` to deploy default installations of the necessary operators.
+Run `helm upgrade --install <release-name> <path-to-chart> --namespace <namespace> --create-namespace` to deploy default installations of the necessary operators.
 
 #### Example
 
-`helm upgrade --install setup-default-operators ./chart`
+`helm upgrade --install ai-rhdh ./chart --namespace rhdh --create-namespace`
 
 ### Uninstall
 
-Since for the default installation the `ServiceAccount` is being deployed to the `default` namespace with admin permissions you are unable to remove it during a `helm uninstall`. You first need to remove the ServiceAccount manually before running `helm uninstall`
+`helm uninstall <release-name> --namespace <namespace>`
+
+#### Default Namespace
+
+Since for the default installation the ServiceAccount is being deployed to the `default` namespace with admin permissions you are unable to remove it during a `helm uninstall`. You first need to remove the ServiceAccount manually before running `helm uninstall`
 
 Reference: https://access.redhat.com/solutions/7055600
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Run `helm upgrade --install <release-name> <path-to-chart> --namespace <namespac
 
 #### Example
 
-`helm upgrade --install ai-rhdh ./chart --namespace rhdh --create-namespace`
+`helm upgrade --install ai-rhdh ./chart --namespace ai-rhdh --create-namespace`
 
 ### Uninstall
 

--- a/README.md
+++ b/README.md
@@ -37,12 +37,6 @@ Run `helm upgrade --install <release-name> <path-to-chart> --namespace <namespac
 
 `helm uninstall <release-name> --namespace <namespace>`
 
-#### Default Namespace
+### Default Namespace
 
-Since for the default installation the ServiceAccount is being deployed to the `default` namespace with admin permissions you are unable to remove it during a `helm uninstall`. You first need to remove the ServiceAccount manually before running `helm uninstall`
-
-Reference: https://access.redhat.com/solutions/7055600
-
-`oc delete sa helm-manager --as backplane-cluster-admin`
-
-After the ServiceAccount is removed, run `helm uninstall <release-name>`
+This installer is incompatible with `default` namespace installations, install and uninstall commands must include `--namespace <target-namespace>` or the context namespace must be changed, e.g. `oc project <target-namespace>`.

--- a/chart/templates/configure.yaml
+++ b/chart/templates/configure.yaml
@@ -24,5 +24,6 @@ spec:
     spec:
       containers:
         {{include "rhdh.gitops.configure" . | indent 8}}
+        {{include "rhdh.developer-hub.configure" . | indent 8 }}
       restartPolicy: Never
       serviceAccountName: helm-manager

--- a/chart/templates/developer-hub/includes/_backstage.tpl
+++ b/chart/templates/developer-hub/includes/_backstage.tpl
@@ -1,0 +1,15 @@
+{{ define "rhdh.include.backstage" }}
+---
+apiVersion: rhdh.redhat.com/v1alpha1
+kind: Backstage
+metadata:
+  name: {{index .Values "developer-hub" "name" | quote }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  application:
+    replicas: 1
+    route:
+      enabled: true
+  database:
+    enableLocalDb: true
+{{ end }}

--- a/chart/templates/developer-hub/includes/_backstage.tpl
+++ b/chart/templates/developer-hub/includes/_backstage.tpl
@@ -3,7 +3,7 @@
 apiVersion: rhdh.redhat.com/v1alpha1
 kind: Backstage
 metadata:
-  name: ai-rhdh-developer-hub
+  name: ai-rh-developer-hub
   namespace: {{ .Release.Namespace }}
 spec:
   application:

--- a/chart/templates/developer-hub/includes/_backstage.tpl
+++ b/chart/templates/developer-hub/includes/_backstage.tpl
@@ -3,7 +3,7 @@
 apiVersion: rhdh.redhat.com/v1alpha1
 kind: Backstage
 metadata:
-  name: {{index .Values "developer-hub" "name" | quote }}
+  name: ai-rhdh-developer-hub
   namespace: {{ .Release.Namespace }}
 spec:
   application:

--- a/chart/templates/developer-hub/includes/_configure.tpl
+++ b/chart/templates/developer-hub/includes/_configure.tpl
@@ -1,0 +1,32 @@
+{{ define "rhdh.developer-hub.configure" }}
+{{ if (index .Values "developer-hub") }}
+- name: configure-developer-hub
+  image: "registry.redhat.io/openshift4/ose-tools-rhel8:latest"
+  workingDir: /tmp
+  command:
+    - /bin/sh
+    - -c
+    - |
+      set -o errexit
+      set -o nounset
+      set -o pipefail
+
+      CRD="backstages"
+      echo -n "* Waiting for '$CRD' CRD: "
+      while [ $(kubectl api-resources | grep -c "^$CRD ") = "0" ] ; do
+        echo -n "."
+        sleep 3
+      done
+      echo "OK"
+
+      #
+      # All actions must be idempotent
+      #
+      NAMESPACE="{{.Release.Namespace}}"
+
+      echo -n "* Creating RHDH instance: "
+      cat <<EOF | kubectl apply -n "$NAMESPACE" -f - >/dev/null
+      {{ include "rhdh.include.backstage" . | indent 6 }}
+      EOF
+{{ end }}
+{{ end }}

--- a/chart/templates/developer-hub/includes/_unconfigure.tpl
+++ b/chart/templates/developer-hub/includes/_unconfigure.tpl
@@ -1,0 +1,24 @@
+{{ define "rhdh.developer-hub.unconfigure" }}
+{{ if (index .Values "developer-hub") }}
+- name: unconfigure-developer-hub
+  image: "registry.redhat.io/openshift4/ose-tools-rhel8:latest"
+  workingDir: /tmp
+  command:
+    - /bin/sh
+    - -c
+    - |
+      set -o errexit
+      set -o nounset
+      set -o pipefail
+
+      #
+      # All actions must be idempotent
+      #
+      NAMESPACE="{{.Release.Namespace}}"
+
+      echo -n "* Deleting RHDH instance: "
+      cat <<EOF | kubectl delete -n "$NAMESPACE" -f - >/dev/null
+      {{ include "rhdh.include.backstage" . | indent 6 }}
+      EOF
+{{ end }}
+{{ end }}

--- a/chart/templates/developer-hub/subscription.yaml
+++ b/chart/templates/developer-hub/subscription.yaml
@@ -1,0 +1,19 @@
+---
+{{ if (index .Values "developer-hub") }}
+{{ if (lookup "operators.coreos.com/v1alpha1" "Subscription" "openshift-operators" "rhdh") }}
+{{else}}
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  annotations:
+    helm.sh/resource-policy: keep
+  name: rhdh
+  namespace: openshift-operators
+spec:
+  channel: {{index .Values "developer-hub" "channel"}}
+  installPlanApproval: Automatic
+  name: rhdh
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+{{end}}
+{{end}}

--- a/chart/templates/openshift-gitops/includes/_argocd.tpl
+++ b/chart/templates/openshift-gitops/includes/_argocd.tpl
@@ -4,7 +4,7 @@ apiVersion: argoproj.io/v1beta1
 kind: ArgoCD
 metadata:
   name: ai-rhdh-argocd
-  namespace: {{ index .Values "openshift-gitops" "argoCD" "namespace" }}
+  namespace: {{ .Release.Namespace }}
 spec:
   server:
     route:

--- a/chart/templates/openshift-gitops/includes/_unconfigure.tpl
+++ b/chart/templates/openshift-gitops/includes/_unconfigure.tpl
@@ -1,0 +1,22 @@
+{{ define "rhdh.gitops.unconfigure" }}
+- name: unconfigure-gitops
+  image: "registry.redhat.io/openshift4/ose-tools-rhel8:latest"
+  workingDir: /tmp
+  command:
+    - /bin/sh
+    - -c
+    - |
+      set -o errexit
+      set -o nounset
+      set -o pipefail
+
+      #
+      # All actions must be idempotent
+      #
+      NAMESPACE="{{.Release.Namespace}}"
+
+      echo -n "* Deleting ArgoCD instance: "
+      cat <<EOF | kubectl delete -n "$NAMESPACE" -f - >/dev/null
+      {{ include "rhdh.include.argocd" . | indent 6 }}
+      EOF
+{{ end }}

--- a/chart/templates/unconfigure.yaml
+++ b/chart/templates/unconfigure.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{.Release.Name}}-unconfigure-operators"
+  labels:
+    app.kubernetes.io/managed-by: {{.Release.Service | quote}}
+    app.kubernetes.io/instance: {{.Release.Name | quote}}
+    app.kubernetes.io/version: {{.Chart.AppVersion}}
+    helm.sh/chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  template:
+    metadata:
+      name: "{{.Release.Name}}-unconfigure-operators"
+      labels:
+        app.kubernetes.io/managed-by: {{.Release.Service | quote}}
+        app.kubernetes.io/instance: {{.Release.Name | quote}}
+        helm.sh/chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+    spec:
+      containers:
+        {{include "rhdh.gitops.unconfigure" . | indent 8 }}
+        {{include "rhdh.developer-hub.unconfigure" . | indent 8 }}
+      restartPolicy: Never
+      serviceAccountName: helm-manager

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -22,3 +22,7 @@ openshift-gitops:
 openshift-pipelines:
   enabled: true
   channel: pipelines-1.14
+developer-hub:
+  enabled: true
+  channel: fast-1.2
+  name: developer-hub

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -23,4 +23,3 @@ openshift-pipelines:
 developer-hub:
   enabled: true
   channel: fast-1.2
-  name: developer-hub

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -8,8 +8,6 @@ openshift-gitops:
   workload-namespaces:
     - default
   argoCD:
-    # Namespace can be changed in an upgrade for configuration of RHDH
-    namespace: default
     # ArgoCD's application-controller resource limits.
     controller:
       resources:


### PR DESCRIPTION
This PR adds the portion of the Helm Chart that facilitates the deployment of the RHDH Operator. This also creates an instance of RHDH in the target namespace.

Portions of this chart were referenced from RHTAP: https://github.com/redhat-appstudio/rhtap-installer/tree/main/chart

## Additional Changes

- https://github.com/redhat-ai-dev/ai-rhdh-installer/commit/83c9bbda6d29835c628f647a8d26f3e621e80263 - fixes argocd instance deployment to use target namespace instead of default namespace
- https://github.com/redhat-ai-dev/ai-rhdh-installer/commit/3f168b4b952ef4402c4c3bfaf1be5ae9910d621d - adds unconfigure batch job to delete resources on `helm uninstall`
- https://github.com/redhat-ai-dev/ai-rhdh-installer/commit/bdd04c76e830658f9bba4e45dd4cdc91c2b7ddb5 - amend instructions to not use default namespace