### PR TITLE
DEVAI-31: Custom Namespace Tekton Task

### DIFF
--- a/resources/dev-setup-task.yaml
+++ b/resources/dev-setup-task.yaml
@@ -1,0 +1,41 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: dev-namespace-setup
+spec:
+  description: |-
+    Create the required resources for AI Software Template tasks to run in a namespace.
+  params:
+    - default: ''
+      description: |
+        Git token
+      name: git_token
+      type: string
+    - default: ''
+      description: |
+        GitLab Personal Access Token
+      name: gitlab_token
+      type: string
+    - default: ''
+      description: |
+        Pipelines as Code webhook secret
+      name: pipelines_webhook_secret
+      type: string
+    - default: ''
+      description: |
+        Image registry token
+      name: quay_dockerconfigjson
+      type: string
+  steps:
+    - env:
+      - name: GIT_TOKEN
+        value: $(params.git_token)
+      - name: GITLAB_TOKEN
+        value: $(params.gitlab_token)
+      - name: PIPELINES_WEBHOOK_SECRET
+        value: $(params.pipelines_webhook_secret)
+      - name: QUAY_DOCKERCONFIGJSON
+        value: $(params.quay_dockerconfigjson)
+      image: "registry.redhat.io/openshift4/ose-tools-rhel8:latest"
+      name: setup
+      script: ''

--- a/scripts/configure-pipelines.sh
+++ b/scripts/configure-pipelines.sh
@@ -212,7 +212,8 @@ if [ ! -z "${GITHUB__APP__WEBHOOK__SECRET}" ]; then
     echo -n "."
 fi
 if [ ! -z "${QUAY__DOCKERCONFIGJSON}" ]; then
-    DEV_SETUP_TASK=$(QUAY__DOCKERCONFIGJSON=${QUAY__DOCKERCONFIGJSON} echo "${DEV_SETUP_TASK}" | yq ".spec.params[3].default = strenv(QUAY__DOCKERCONFIGJSON)" -M)
+    export QUAY__DOCKERCONFIGJSON=${QUAY__DOCKERCONFIGJSON}
+    DEV_SETUP_TASK=$(echo "${DEV_SETUP_TASK}" | yq ".spec.params[3].default = strenv(QUAY__DOCKERCONFIGJSON)" -M)
     if [ $? -ne 0 ]; then
         echo -n "FAIL"
         exit 1

--- a/scripts/configure-pipelines.sh
+++ b/scripts/configure-pipelines.sh
@@ -163,9 +163,9 @@ if [ "$(kubectl get secret -n "${PIPELINES_NAMESPACE}" "pipelines-as-code-secret
 fi
 echo "OK"
 
-# Configure Namespaces
-# Configuring namespaces with needed resources
-echo -n "* Configuring Namespaces: "
+# Fetching cosign public key
+# Fetches cosign public key needed for namespace setup
+echo -n "* Fetching cosign public key: "
 while ! kubectl get secrets -n openshift-pipelines signing-secrets >/dev/null 2>&1; do
     echo -n "_"
     sleep 2
@@ -181,6 +181,141 @@ while [ -z "${COSIGN_SIGNING_PUBLIC_KEY:-}" ]; do
         exit 1
     fi
 done
+echo "OK"
+
+# Creating Namespace Setup Tekton Task Definition
+# Creates Tekton Task definition for creating custom namespaces with needed resources
+echo -n "* Creating Namespace Setup Tekton Task Definition: "
+DEV_SETUP_TASK=$(cat $BASE_DIR/resources/dev-setup-task.yaml)
+if [ ! -z "${GITOPS__GIT_TOKEN}" ]; then
+    DEV_SETUP_TASK=$(echo "${DEV_SETUP_TASK}" | yq ".spec.params[0].default = \"${GITOPS__GIT_TOKEN}\"" -M)
+    if [ $? -ne 0 ]; then
+        echo -n "FAIL"
+        exit 1
+    fi
+    echo -n "."
+fi
+if [ ! -z "${GITLAB__TOKEN}" ]; then
+    DEV_SETUP_TASK=$(echo "${DEV_SETUP_TASK}" | yq ".spec.params[1].default = \"${GITLAB__TOKEN}\"" -M)
+    if [ $? -ne 0 ]; then
+        echo -n "FAIL"
+        exit 1
+    fi
+    echo -n "."
+fi
+if [ ! -z "${GITHUB__APP__WEBHOOK__SECRET}" ]; then
+    DEV_SETUP_TASK=$(echo "${DEV_SETUP_TASK}" | yq ".spec.params[2].default = \"${GITHUB__APP__WEBHOOK__SECRET}\"" -M)
+    if [ $? -ne 0 ]; then
+        echo -n "FAIL"
+        exit 1
+    fi
+    echo -n "."
+fi
+if [ ! -z "${QUAY__DOCKERCONFIGJSON}" ]; then
+    DEV_SETUP_TASK=$(QUAY__DOCKERCONFIGJSON=${QUAY__DOCKERCONFIGJSON} echo "${DEV_SETUP_TASK}" | yq ".spec.params[3].default = strenv(QUAY__DOCKERCONFIGJSON)" -M)
+    if [ $? -ne 0 ]; then
+        echo -n "FAIL"
+        exit 1
+    fi
+    echo -n "."
+fi
+export TASK_SCRIPT="#!/usr/bin/env bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+SECRET_NAME=\"cosign-pub\"
+if [ -n \"$COSIGN_SIGNING_PUBLIC_KEY\" ]; then
+  echo -n \"* \$SECRET_NAME secret: \"
+  cat <<EOF | kubectl apply -f - >/dev/null
+apiVersion: v1
+data:
+  cosign.pub: $COSIGN_SIGNING_PUBLIC_KEY
+kind: Secret
+metadata:
+  labels:
+  app.kubernetes.io/instance: default
+  app.kubernetes.io/part-of: tekton-chains
+  operator.tekton.dev/operand-name: tektoncd-chains
+  name: \$SECRET_NAME
+type: Opaque
+EOF
+  echo \"OK\"
+fi
+
+SECRET_NAME=\"gitlab-auth-secret\"
+if [ -n \"\$GITLAB_TOKEN\" ]; then
+  echo -n \"* \$SECRET_NAME secret: \"
+  kubectl create secret generic \"\$SECRET_NAME\" \\
+    --from-literal=password=\$GITLAB_TOKEN \\
+    --from-literal=username=oauth2 \\
+    --type=kubernetes.io/basic-auth \\
+    --dry-run=client -o yaml | kubectl apply --filename - --overwrite=true >/dev/null
+  echo \"OK\"
+fi
+
+SECRET_NAME=\"gitops-auth-secret\"
+if [ -n \"\$GIT_TOKEN\" ]; then
+  echo -n \"* \$SECRET_NAME secret: \"
+  kubectl create secret generic \"\$SECRET_NAME\" \\
+    --from-literal=password=\$GIT_TOKEN \\
+    --type=kubernetes.io/basic-auth \\
+    --dry-run=client -o yaml | kubectl apply --filename - --overwrite=true >/dev/null
+  echo \"OK\"
+fi
+
+SECRET_NAME=\"pipelines-secret\"
+if [ -n \"\$PIPELINES_WEBHOOK_SECRET\" ]; then
+  echo -n \"* \$SECRET_NAME secret: \"
+  kubectl create secret generic \"\$SECRET_NAME\" \\
+    --from-literal=webhook.secret=\$PIPELINES_WEBHOOK_SECRET \\
+    --dry-run=client -o yaml | kubectl apply --filename - --overwrite=true >/dev/null
+  echo \"OK\"
+fi
+
+SECRET_NAME=\"rhdh-image-registry-token\"
+if [ -n \"\$QUAY_DOCKERCONFIGJSON\" ]; then
+  echo -n \"* \$SECRET_NAME secret: \"
+  DATA=\$(mktemp)
+  echo -n \"\$QUAY_DOCKERCONFIGJSON\" >\"\$DATA\"
+  kubectl create secret docker-registry \"\$SECRET_NAME\" \\
+    --from-file=.dockerconfigjson=\"\$DATA\" --dry-run=client -o yaml | \\
+    kubectl apply --filename - --overwrite=true >/dev/null
+  rm \"\$DATA\"
+  echo -n \".\"
+  while ! kubectl get serviceaccount pipeline >/dev/null &>2; do
+    sleep 2
+    echo -n \"_\"
+  done
+  for SA in default pipeline; do
+    kubectl patch serviceaccounts \"\$SA\" --patch \"
+  secrets:
+    - name: \$SECRET_NAME
+  imagePullSecrets:
+    - name: \$SECRET_NAME
+  \" >/dev/null
+    echo -n \".\"
+  done
+  echo \"OK\"
+fi"
+DEV_SETUP_TASK=$(echo "${DEV_SETUP_TASK}" | yq ".spec.steps[0].script = strenv(TASK_SCRIPT)" -M)
+if [ $? -ne 0 ]; then
+    echo -n "FAIL"
+    exit 1
+fi
+echo -n "."
+cat <<EOF | kubectl apply -n ${NAMESPACE} -f - >/dev/null
+${DEV_SETUP_TASK}
+EOF
+if [ $? -ne 0 ]; then
+    echo -n "FAIL"
+    exit 1
+fi
+echo "OK"
+
+# Configure Namespaces
+# Configuring namespaces with needed resources
+echo -n "* Configuring Namespaces: "
 for NAMESPACE_SUFFIX in "development" "prod" "stage"; do
     APP_NAMESPACE="${NAMESPACE}-app-${NAMESPACE_SUFFIX}"
 

--- a/scripts/configure-pipelines.sh
+++ b/scripts/configure-pipelines.sh
@@ -234,9 +234,9 @@ data:
 kind: Secret
 metadata:
   labels:
-  app.kubernetes.io/instance: default
-  app.kubernetes.io/part-of: tekton-chains
-  operator.tekton.dev/operand-name: tektoncd-chains
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-chains
+    operator.tekton.dev/operand-name: tektoncd-chains
   name: \$SECRET_NAME
 type: Opaque
 EOF


### PR DESCRIPTION
### What does this PR do?:
<!-- _Summarize the changes_ -->

Adds a Tekton Task to the RHDH namespace during run of `configure-pipelines.sh` so that users can target different namespaces for their apps and the Tekton Task will setup up that target namespace with the resources it needs to manage the deployments.

### Which issue(s) this PR fixes:
<!-- _Link to Github/JIRA issue(s)_ -->

resolves missing part of https://issues.redhat.com/browse/DEVAI-31

### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened and linked to this PR, if they are not in the PR scope due to various constraints.

- [x] Tested and Verified

  <!-- _I have verified that the changes were tested manually_ -->

- [x] Documentation (READMEs, Product Docs, Blogs, Education Modules, etc.)

   <!-- _This includes READMEs, Product Docs, Blogs, Education Modules, etc._ -->


### How to test changes / Special notes to the reviewer:
