### PR TITLE
Add disclaimer that only github authentication is supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This helm chart installs and configures the following operators:
 - Helm CLI (more information [here](https://helm.sh/docs/intro/install/))
 - GitHub or GitLab App created via [APP-SETUP.md](./docs/APP-SETUP.md)
 
-## CLI
+## Helm Chart Installer
 
 ### Install
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,17 @@ For convenience you can configure your Red Hat Developer Hub, GitOps, and Pipeli
 
 **Note**: If you changed the installation namespace used by the installer you will first need to run `export NAMESPACE=<namespace used>` as the default value is `ai-rhdh`.
 
-Alternatively, if you do not wish to use the all-in-one `configure.sh` script, you can find documentation below for configuring each component individually.
+See the following for further customization of the configuration:
+
+- [Enabling GitLab Integration](#gitlab-integration)
+- [Setting Environment Variables](#setting-environment-variables-for-configuration-scripts)
+- [Setting Catalogs for Developer Hub Configuration](#setting-catalogs-for-developer-hub-configuration)
+
+Alternatively, if you do not wish to use the all-in-one `configure.sh` script, you can find documentation below for configuring each component individually:
+
+- [GitOps/ArgoCD Configuration](#gitopsargocd-configuration)
+- [Pipelines/Tekton Configuration](#pipelinestekton-configuration)
+- [Developer Hub Configuration](#developer-hub-configuration)
 
 ### GitOps/ArgoCD Configuration
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ Detailed documentation for configuring Pipelines/Tekton can be found in [`PIPELI
 
 Detailed documentation for configuring Developer Hub can be found in [`RHDH-CONFIG.md`](./docs/RHDH-CONFIG.md).
 
+## GitLab Integration
+
+To configure RHDH to use GitLab as the git repository source, you will need to first run `export RHDH_GITLAB_INTEGRATION=true` before running any of the [configuration](#configuration) scripts. Run `export RHDH_GITHUB_INTEGRATION=false` to disable GitHub integration.
+
 ## Setting Environment Variables for Configuration Scripts
 
 For more information regarding where you can obtain these values see [APP-SETUP.md](./docs/APP-SETUP.md)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Red Hat Developer Hub Installer for AI Software Templates
 
+> [!IMPORTANT] 
 > Currently, only the **GitHub Authentication** is supported. **GitLab Authentication** is planned for future versions.
 
 This helm chart installs and configures the following operators:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Red Hat Developer Hub Installer for AI Software Templates
 
-> We are only supporting **GitHub Authentication**, **GitLab Authentication** is planned for future versions.
+> Currently, only the **GitHub Authentication** is supported. **GitLab Authentication** is planned for future versions.
 
 This helm chart installs and configures the following operators:
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Red Hat Developer Hub Installer for AI Software Templates
 
+> We are only supporting **GitHub Authentication**, **GitLab Authentication** is planned for future versions.
+
 This helm chart installs and configures the following operators:
 
 |       Product       |      Installation       |                                                                                                      Configuration                                                                                                       |


### PR DESCRIPTION
### What does this PR do?:
<!-- _Summarize the changes_ -->

Adds disclaimer to README that only github log in is supported for RHDH user authentication with GitLab log in planned for future versions.

**Additional Changes**

- Adds a GitLab Integration section to README to outline how to enable
- Changes 'CLI' section to 'Helm Chart Installer' to make title more clear
- Adds list of related sections for configuration section under the README

### Which issue(s) this PR fixes:
<!-- _Link to Github/JIRA issue(s)_ -->

https://issues.redhat.com/browse/DEVAI-221

### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened and linked to this PR, if they are not in the PR scope due to various constraints.

- [ ] Tested and Verified

  <!-- _I have verified that the changes were tested manually_ -->

- [X] Documentation (READMEs, Product Docs, Blogs, Education Modules, etc.)

   <!-- _This includes READMEs, Product Docs, Blogs, Education Modules, etc._ -->


### How to test changes / Special notes to the reviewer:
