### PR TITLE
Revise RHDH operator missing required app config fields disclaimer

### DIFF
--- a/docs/RHDH-CONFIG.md
+++ b/docs/RHDH-CONFIG.md
@@ -327,7 +327,7 @@ data:
         origin: https://backstage-ai-rh-developer-hub-ai-rhdh.apps.example-cluster.devcluster.openshift.com
 ```
 
-**Note**: Having these fields set under any app config ConfigMap tied to the existing RHDH instance should work. See [Configuring the Developer Hub Custom Resource](https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.1/html/administration_guide_for_red_hat_developer_hub/assembly-install-rhdh-ocp#proc-config-rhdh-custom-resource_admin-rhdh) for further details about setting up the RHDH app config.
+**Note**: Having these fields set under any app config ConfigMap tied to the existing RHDH instance should work. See [Configuring the Developer Hub Custom Resource](https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.2/html/administration_guide_for_red_hat_developer_hub/assembly-add-custom-app-file-openshift_admin-rhdh#proc-add-custom-app-config-file-ocp-operator_admin-rhdh) for further details about setting up the RHDH app config.
 
 If you are planning to use GitHub integration run `export RHDH_GITHUB_INTEGRATION=true` and to use GitLab integration run `export RHDH_GITLAB_INTEGRATION=true`. 
 

--- a/docs/RHDH-CONFIG.md
+++ b/docs/RHDH-CONFIG.md
@@ -313,7 +313,21 @@ If using a [RHDH Operator](https://github.com/redhat-developer/rhdh-operator) in
 - `.backend.baseUrl`
 - `.backend.cors.origin`
 
-You will need to ensure the above fields are set to the developer hub entrypoint url the tied app config. **Note**: Having these fields set under any app config ConfigMap tied to the existing RHDH instance should work. 
+You will need to ensure the above fields are set to the developer hub entrypoint url the tied app config. For example:
+
+```yaml
+data:
+  app-config.base.yaml: |
+    app:
+      title: "Red Hat Developer Hub for AI Software Templates"
+      baseUrl: https://backstage-ai-rh-developer-hub-ai-rhdh.apps.example-cluster.devcluster.openshift.com
+    backend:
+      baseUrl: https://backstage-ai-rh-developer-hub-ai-rhdh.apps.example-cluster.devcluster.openshift.com
+      cors:
+        origin: https://backstage-ai-rh-developer-hub-ai-rhdh.apps.example-cluster.devcluster.openshift.com
+```
+
+**Note**: Having these fields set under any app config ConfigMap tied to the existing RHDH instance should work. 
 
 If you are planning to use GitHub integration run `export RHDH_GITHUB_INTEGRATION=true` and to use GitLab integration run `export RHDH_GITLAB_INTEGRATION=true`. 
 

--- a/docs/RHDH-CONFIG.md
+++ b/docs/RHDH-CONFIG.md
@@ -327,7 +327,7 @@ data:
         origin: https://backstage-ai-rh-developer-hub-ai-rhdh.apps.example-cluster.devcluster.openshift.com
 ```
 
-**Note**: Having these fields set under any app config ConfigMap tied to the existing RHDH instance should work. 
+**Note**: Having these fields set under any app config ConfigMap tied to the existing RHDH instance should work. See [Configuring the Developer Hub Custom Resource](https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.1/html/administration_guide_for_red_hat_developer_hub/assembly-install-rhdh-ocp#proc-config-rhdh-custom-resource_admin-rhdh) for further details about setting up the RHDH app config.
 
 If you are planning to use GitHub integration run `export RHDH_GITHUB_INTEGRATION=true` and to use GitLab integration run `export RHDH_GITLAB_INTEGRATION=true`. 
 

--- a/docs/RHDH-CONFIG.md
+++ b/docs/RHDH-CONFIG.md
@@ -308,10 +308,12 @@ You are able to store these values in environment variables. Set the following t
 - `$EXISTING_EXTRA_ENV_SECRET`
   - Name of the extra environment variables Secret
 
-If using a [RHDH Operator](https://github.com/redhat-developer/rhdh-operator) instance, you will need to ensure the following fields are set to the developer hub entrypoint url under any of the app configs tied to your developer hub instance: 
+If using a [RHDH Operator](https://github.com/redhat-developer/rhdh-operator) instance the following required fields will be missing **by default (unless already setup)**:
 - `.app.baseUrl`
 - `.backend.baseUrl`
 - `.backend.cors.origin`
+
+You will need to ensure the above fields are set to the developer hub entrypoint url the tied app config. **Note**: Having these fields set under any app config ConfigMap tied to the existing RHDH instance should work. 
 
 If you are planning to use GitHub integration run `export RHDH_GITHUB_INTEGRATION=true` and to use GitLab integration run `export RHDH_GITLAB_INTEGRATION=true`. 
 


### PR DESCRIPTION
### What does this PR do?:
<!-- _Summarize the changes_ -->

Revises RHDH operator missing required app config fields disclaimer to make clear that the following field **must** be set under a tied app config if not already:

- `.app.baseUrl`
- `.backend.baseUrl`
- `.backend.cors.origin`

Also provides example for how this should be done.

### Which issue(s) this PR fixes:
<!-- _Link to Github/JIRA issue(s)_ -->

https://issues.redhat.com/browse/DEVAI-235

### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened and linked to this PR, if they are not in the PR scope due to various constraints.

- [ ] Tested and Verified

  <!-- _I have verified that the changes were tested manually_ -->

- [X] Documentation (READMEs, Product Docs, Blogs, Education Modules, etc.)

   <!-- _This includes READMEs, Product Docs, Blogs, Education Modules, etc._ -->


### How to test changes / Special notes to the reviewer:
