### PR TITLE
[RHDHPAI-312] Add Kubernetes Service Account Token

### DIFF
--- a/chart/templates/k8s-serviceaccount.yaml
+++ b/chart/templates/k8s-serviceaccount.yaml
@@ -17,3 +17,11 @@ subjects:
   - kind: ServiceAccount
     name: rhdh-kubernetes-plugin
     namespace: {{.Release.Namespace}}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rhdh-kubernetes-plugin-token
+  annotations:
+    kubernetes.io/service-account.name: rhdh-kubernetes-plugin
+type: kubernetes.io/service-account-token

--- a/chart/templates/k8s-serviceaccount.yaml
+++ b/chart/templates/k8s-serviceaccount.yaml
@@ -22,6 +22,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: rhdh-kubernetes-plugin-token
+  namespace: {{.Release.Namespace}}
   annotations:
     kubernetes.io/service-account.name: rhdh-kubernetes-plugin
 type: kubernetes.io/service-account-token

--- a/docs/pipelines/INSTALLER-PROVISIONED.md
+++ b/docs/pipelines/INSTALLER-PROVISIONED.md
@@ -33,7 +33,7 @@ cat resources/tekton-config.yaml | kubectl patch tektonconfig config --type 'mer
 
 #### Step 2: RHDH Kubernetes Plugin Service Account
 
-As part of the `ai-rhdh-installer` a service account with a token secret was created in your desired namespace with the name `rhdh-kubernetes-plugin`, token secret should have a name pattern `rhdh-kubernetes-plugin-token-*`, keep note of this Secret.
+As part of the `ai-rhdh-installer` a service account with a token secret was created in your desired namespace with the name `rhdh-kubernetes-plugin`, token secret should have the name `rhdh-kubernetes-plugin-token`, keep note of this Secret.
 
 #### Step 3: Create App Namespace Setup Task
 

--- a/docs/pipelines/KUBERNETES_SERVICEACCOUNT.md
+++ b/docs/pipelines/KUBERNETES_SERVICEACCOUNT.md
@@ -1,0 +1,41 @@
+# Setting Up Kubernetes Service Accounts
+
+## Creating The Service Account
+
+You will need to create a Service Account that RHDH needs to interact with the cluster. The yaml snippet found below can be used to easily create a Service Account.
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rhdh-kubernetes-plugin
+  namespace: <desired-namespace>
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rhdh-kubernetes-plugin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+  - kind: ServiceAccount
+    name: rhdh-kubernetes-plugin
+    namespace: <desired-namespace>
+```
+
+## Creating The Service Account Token
+
+In Kubernetes v1.24 and above the token associated with a Service Account is not auto-generated, due to this we will manually create the Service Account Token Secret. This is compatible even for Kubernetes versions older than v1.24.
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rhdh-kubernetes-plugin-token
+  namespace: <desired-namespace>
+  annotations:
+    kubernetes.io/service-account.name: rhdh-kubernetes-plugin
+type: kubernetes.io/service-account-token
+```

--- a/docs/pipelines/PRE-EXISTING.md
+++ b/docs/pipelines/PRE-EXISTING.md
@@ -76,7 +76,7 @@ First you will need to create the [service account](../../chart/templates/k8s-se
 that RHDH will need to interact with the cluster such as
 creating tekton pipeline runs.
 
-Once the service account is created there will be a tied secret which stores the service account token, e.g. if a service account `rhdh-kubernetes-plugin` is created then a secret with the name pattern `rhdh-kubernetes-plugin-token-*` is also created.
+Once the service account is created there will be a tied secret which stores the service account token, e.g. if a service account `rhdh-kubernetes-plugin` is created then a secret with the name `rhdh-kubernetes-plugin-token` is also created.
 
 Keep note of the name of this secret.
 

--- a/docs/pipelines/PRE-EXISTING.md
+++ b/docs/pipelines/PRE-EXISTING.md
@@ -72,13 +72,9 @@ Once you have done the prior steps and have the information from the prior steps
 You will follow the same steps as [step 3 of the script configuration for a pre-existing instance](#step-3-configure-cosign).
 
 #### Step 2: Kubernetes API Service Account
-First you will need to create the [service account](../../chart/templates/k8s-serviceaccount.yaml)
-that RHDH will need to interact with the cluster such as
-creating tekton pipeline runs.
+You will first need to create a Kubernetes Service Account. You can reference [`KUBERNETES_SERVICEACCOUNT.md`](./KUBERNETES_SERVICEACCOUNT.md) for more information on how to create these resources.
 
-Once the service account is created there will be a tied secret which stores the service account token, e.g. if a service account `rhdh-kubernetes-plugin` is created then a secret with the name `rhdh-kubernetes-plugin-token` is also created.
-
-Keep note of the name of this secret.
+It is important to keep in mind the name of both the Service Account and the Token Secret.
 
 #### Step 3: Create App Namespace Setup Task
 

--- a/docs/rhdh/INSTALLER-PROVISIONED.md
+++ b/docs/rhdh/INSTALLER-PROVISIONED.md
@@ -312,7 +312,7 @@ Now you will need to make sure that all of the ArgoCD and Tekton tied resources 
 Run the following to patch in the Kubernetes Service Account Token that is needed for use under the Kubernetes dynamic plugin:
 
 ```sh
-K8S_SA_SECRET_NAME=$(kubectl get secrets -n "$NAMESPACE" -o name | grep rhdh-kubernetes-plugin-token- | cut -d/ -f2 | head -1)
+K8S_SA_SECRET_NAME=$(kubectl get secrets -n "$NAMESPACE" -o name | grep rhdh-kubernetes-plugin-token | cut -d/ -f2 | head -1)
 K8S_SA_TOKEN=$(kubectl -n $NAMESPACE get secret $K8S_SA_SECRET_NAME -o yaml | yq '.data.token' -M -I=0)
 kubectl -n $NAMESPACE patch secret ai-rh-developer-hub-env \
     --type 'merge' \

--- a/docs/rhdh/PRE-EXISTING.md
+++ b/docs/rhdh/PRE-EXISTING.md
@@ -174,7 +174,7 @@ kubectl -n $NAMESPACE create secret generic ai-rh-developer-hub-env \
 
 Notice that `K8S_SA_TOKEN` does not need encoding as the other literal sets, this is because when the value is fetched from the Service Account Token Secret it comes back already encoded.
 
-#### Step 2: Setting the Extra Environment Variables Secret to Developer Hub
+#### Step 3: Setting the Extra Environment Variables Secret to Developer Hub
 
 You will need to set up your Developer Hub instance to use the Extra Environment Variables Secret you created. To do this you will need to patch the Secret into the deployment by doing either of the following:
 
@@ -196,11 +196,11 @@ kubectl get deploy <rhdh-deployment-name> -n $NAMESPACE -o yaml | \
   kubectl apply -f -
 ```
 
-#### Step 3: Create the Extra App Config ConfigMap
+#### Step 4: Create the Extra App Config ConfigMap
 
 Follow the same steps under [step 2 for the ai-rhdh-installer](./INSTALLER-PROVISIONED.md#step-2-create-the-extra-app-config-configmap).
 
-#### Step 4: Setting the Extra App Config to Developer Hub
+#### Step 5: Setting the Extra App Config to Developer Hub
 
 Similar to [step 3 for the ai-rhdh-installer](./INSTALLER-PROVISIONED.md#step-3-setting-the-extra-app-config-to-developer-hub), you will need to set up your Developer Hub instance to use the Extra App Config you created. To do this you will need to patch the app config into the deployment spec:
 
@@ -214,19 +214,19 @@ kubectl get deploy <rhdh-deployment-name> -n $NAMESPACE -o yaml | \
 
 **Note**: If you are bringing your own [RHDH Operator](https://github.com/redhat-developer/rhdh-operator) instance, you can follow [step 3 for the ai-rhdh-installer](./INSTALLER-PROVISIONED.md#step-3-setting-the-extra-app-config-to-developer-hub) instead.
 
-#### Step 5: Updating ArgoCD Plugins
+#### Step 6: Updating ArgoCD Plugins
 
 Follow the same steps under either [step 4.1](./INSTALLER-PROVISIONED.md#step-41-updating-argocd-plugins-via-web-console) or [step 4.2](./INSTALLER-PROVISIONED.md#step-42-updating-argocd-plugins-via-cli) for the ai-rhdh-installer.
 
-#### Step 6: Updating Tekton Plugins
+#### Step 7: Updating Tekton Plugins
 
 Follow the same steps under either [step 5.1](./INSTALLER-PROVISIONED.md#step-51-updating-tekton-plugins-via-web-console) or [step 5.2](./INSTALLER-PROVISIONED.md#step-52-updating-tekton-plugins-via-cli) for the ai-rhdh-installer.
 
-#### Step 7: Updating Developer Hub Plugins
+#### Step 8: Updating Developer Hub Plugins
 
 Follow the same steps under either [step 6.1](./INSTALLER-PROVISIONED.md#step-61-updating-developer-hub-plugins-via-web-console) or [step 6.2](./INSTALLER-PROVISIONED.md#step-62-updating-developer-hub-plugins-via-cli) for the ai-rhdh-installer.
 
-#### Step 8: Updating RHDH Deployment with ArgoCD Resources
+#### Step 9: Updating RHDH Deployment with ArgoCD Resources
 
 Now you will need to make sure that all of the ArgoCD tied resources are setup with the Developer Hub deployment. Run the following to attach the ArgoCD ConfigMap and Secret:
 

--- a/docs/rhdh/PRE-EXISTING.md
+++ b/docs/rhdh/PRE-EXISTING.md
@@ -67,7 +67,13 @@ Once you have done the prior steps and have the information from the prior steps
 
 ### Manual Configuration
 
-#### Step 1: Create Extra Environment Variables Secret
+#### Step 1: Create Kubernetes Service Account and Token
+
+You can skip this step if these resources are already present in your desired namespace.
+
+For information related to creating these resources see [`KUBERNETES_SERVICEACCOUNT.md`](../pipelines/KUBERNETES_SERVICEACCOUNT.md).
+
+#### Step 2: Create Extra Environment Variables Secret
 
 You will need to create a Secret to store all the private environment variables for RHDH. This can be done one of the following ways:
 

--- a/docs/rhdh/PRE-EXISTING.md
+++ b/docs/rhdh/PRE-EXISTING.md
@@ -74,7 +74,7 @@ You will need to create a Secret to store all the private environment variables 
 **No Integration**
 
 ```sh
-K8S_SA_SECRET_NAME=$(kubectl get secrets -n "$NAMESPACE" -o name | grep rhdh-kubernetes-plugin-token- | cut -d/ -f2 | head -1)
+K8S_SA_SECRET_NAME=$(kubectl get secrets -n "$NAMESPACE" -o name | grep rhdh-kubernetes-plugin-token | cut -d/ -f2 | head -1)
 K8S_SA_TOKEN=$(kubectl -n $NAMESPACE get secret $K8S_SA_SECRET_NAME -o yaml | yq '.data.token' -M -I=0)
 kubectl -n $NAMESPACE create secret generic ai-rh-developer-hub-env \
     --from-literal=NODE_TLS_REJECT_UNAUTHORIZED=$(echo "0" | base64) \
@@ -84,7 +84,7 @@ kubectl -n $NAMESPACE create secret generic ai-rh-developer-hub-env \
 **GitHub**
 
 ```sh
-K8S_SA_SECRET_NAME=$(kubectl get secrets -n "$NAMESPACE" -o name | grep rhdh-kubernetes-plugin-token- | cut -d/ -f2 | head -1)
+K8S_SA_SECRET_NAME=$(kubectl get secrets -n "$NAMESPACE" -o name | grep rhdh-kubernetes-plugin-token | cut -d/ -f2 | head -1)
 K8S_SA_TOKEN=$(kubectl -n $NAMESPACE get secret $K8S_SA_SECRET_NAME -o yaml | yq '.data.token' -M -I=0)
 kubectl -n $NAMESPACE create secret generic ai-rh-developer-hub-env \
     --from-literal=NODE_TLS_REJECT_UNAUTHORIZED=$(echo "0" | base64) \
@@ -102,7 +102,7 @@ kubectl -n $NAMESPACE create secret generic ai-rh-developer-hub-env \
 **GitHub Enterprise**
 
 ```sh
-K8S_SA_SECRET_NAME=$(kubectl get secrets -n "$NAMESPACE" -o name | grep rhdh-kubernetes-plugin-token- | cut -d/ -f2 | head -1)
+K8S_SA_SECRET_NAME=$(kubectl get secrets -n "$NAMESPACE" -o name | grep rhdh-kubernetes-plugin-token | cut -d/ -f2 | head -1)
 K8S_SA_TOKEN=$(kubectl -n $NAMESPACE get secret $K8S_SA_SECRET_NAME -o yaml | yq '.data.token' -M -I=0)
 kubectl -n $NAMESPACE create secret generic ai-rh-developer-hub-env \
     --from-literal=NODE_TLS_REJECT_UNAUTHORIZED=$(echo "0" | base64) \
@@ -121,7 +121,7 @@ kubectl -n $NAMESPACE create secret generic ai-rh-developer-hub-env \
 **GitLab**
 
 ```sh
-K8S_SA_SECRET_NAME=$(kubectl get secrets -n "$NAMESPACE" -o name | grep rhdh-kubernetes-plugin-token- | cut -d/ -f2 | head -1)
+K8S_SA_SECRET_NAME=$(kubectl get secrets -n "$NAMESPACE" -o name | grep rhdh-kubernetes-plugin-token | cut -d/ -f2 | head -1)
 K8S_SA_TOKEN=$(kubectl -n $NAMESPACE get secret $K8S_SA_SECRET_NAME -o yaml | yq '.data.token' -M -I=0)
 kubectl -n $NAMESPACE create secret generic ai-rh-developer-hub-env \
     --from-literal=NODE_TLS_REJECT_UNAUTHORIZED=$(echo "0" | base64) \
@@ -134,7 +134,7 @@ kubectl -n $NAMESPACE create secret generic ai-rh-developer-hub-env \
 **GitLab Self-hosted**
 
 ```sh
-K8S_SA_SECRET_NAME=$(kubectl get secrets -n "$NAMESPACE" -o name | grep rhdh-kubernetes-plugin-token- | cut -d/ -f2 | head -1)
+K8S_SA_SECRET_NAME=$(kubectl get secrets -n "$NAMESPACE" -o name | grep rhdh-kubernetes-plugin-token | cut -d/ -f2 | head -1)
 K8S_SA_TOKEN=$(kubectl -n $NAMESPACE get secret $K8S_SA_SECRET_NAME -o yaml | yq '.data.token' -M -I=0)
 kubectl -n $NAMESPACE create secret generic ai-rh-developer-hub-env \
     --from-literal=NODE_TLS_REJECT_UNAUTHORIZED=$(echo "0" | base64) \
@@ -148,7 +148,7 @@ kubectl -n $NAMESPACE create secret generic ai-rh-developer-hub-env \
 **GitHub & GitLab**
 
 ```sh
-K8S_SA_SECRET_NAME=$(kubectl get secrets -n "$NAMESPACE" -o name | grep rhdh-kubernetes-plugin-token- | cut -d/ -f2 | head -1)
+K8S_SA_SECRET_NAME=$(kubectl get secrets -n "$NAMESPACE" -o name | grep rhdh-kubernetes-plugin-token | cut -d/ -f2 | head -1)
 K8S_SA_TOKEN=$(kubectl -n $NAMESPACE get secret $K8S_SA_SECRET_NAME -o yaml | yq '.data.token' -M -I=0)
 kubectl -n $NAMESPACE create secret generic ai-rh-developer-hub-env \
     --from-literal=NODE_TLS_REJECT_UNAUTHORIZED=$(echo "0" | base64) \

--- a/scripts/configure-dh.sh
+++ b/scripts/configure-dh.sh
@@ -452,7 +452,7 @@ fi
 
 # Add Tekton information and plugin to backstage deployment data
 echo -n "* Adding Tekton information and plugin to backstage deployment data: "
-K8S_SA_SECRET_NAME=$(kubectl get secrets -n "$NAMESPACE" -o name | grep rhdh-kubernetes-plugin-token- | cut -d/ -f2 | head -1)
+K8S_SA_SECRET_NAME=$(kubectl get secrets -n "$NAMESPACE" -o name | grep rhdh-kubernetes-plugin-token | cut -d/ -f2 | head -1)
 if [ $? -ne 0 ]; then
     echo "FAIL"
     exit 1


### PR DESCRIPTION
### What does this PR do?:
<!-- _Summarize the changes_ -->
This PR adds a new definition to the Kubernetes resources being created by the Helm chart to allow for a Kubernetes Service Account token to be created and linked to the SA. This is required because in later versions of Kubernetes SA's don't automatically generate their tokens. This change will not affect the functionality of the installer when deploying to OCP versions that _do_ automatically generate that token as it will just reference the manually created one.

This was tested with RHDH `v1.4` on all of its supported OCP versions, `v4.14`, `v4.15`, `v4.16`, and `v4.17`.


### Which issue(s) this PR fixes:
<!-- _Link to Github/JIRA issue(s)_ -->

https://issues.redhat.com/browse/RHDHPAI-312

### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened and linked to this PR, if they are not in the PR scope due to various constraints.

- [x] Tested and Verified

  <!-- _I have verified that the changes were tested manually_ -->

- [x] Documentation (READMEs, Product Docs, Blogs, Education Modules, etc.)

   <!-- _This includes READMEs, Product Docs, Blogs, Education Modules, etc._ -->


### How to test changes / Special notes to the reviewer:
Run the installer on any of the supported OCP versions and navigate to the `Kubernetes` and `Topology` tabs of a deployed Component, you will no longer see the error being presented and instead can see it working as expected.