### PR TITLE
RHDHPAI-593: add option to allow API access for CI

### DIFF
--- a/docs/EXTRA-CONFIG.md
+++ b/docs/EXTRA-CONFIG.md
@@ -56,6 +56,8 @@ By running `configure.sh` you have the option of giving your input via CLI or by
         - Target model URL for lightspeed plugin
     - `LIGHTSPEED_API_TOKEN`
         - API token for lightspeed plugin model service
+    - `RHDH_DISABLE_AUTH_POLICY`
+        - Disable API request authentication for RHDH. Useful for testing/automation purposes. **Do not use in production**. Accepts `true` or `false`.
 
 ## Setting Catalogs for Developer Hub Configuration
 

--- a/scripts/configure-dh.sh
+++ b/scripts/configure-dh.sh
@@ -364,6 +364,12 @@ if [[ $LIGHTSPEED_INTEGRATION == "true" ]]; then
     fi
     echo -n "."
 fi
+# Only use for running end-to-end tests in CI, keep away from production
+if [[ $CI_DISABLE_AUTH == "true" ]]; then
+    EXTRA_APPCONFIG=$(echo "$EXTRA_APPCONFIG" | yq ".backend.auth.dangerouslyDisableDefaultAuthPolicy = true" -M -)
+    echo -n "."
+fi
+
 EXTRA_APPCONFIG=$EXTRA_APPCONFIG yq ".data[\"app-config.extra.yaml\"] = strenv(EXTRA_APPCONFIG)" $BASE_DIR/resources/developer-hub-app-config.yaml | \
     kubectl -n $NAMESPACE apply -f - >/dev/null
 if [ $? -ne 0 ]; then

--- a/scripts/configure-dh.sh
+++ b/scripts/configure-dh.sh
@@ -25,6 +25,7 @@ RHDH_INSTANCE_PROVIDED=${RHDH_INSTANCE_PROVIDED:-false}
 RHDH_GITHUB_INTEGRATION=${RHDH_GITHUB_INTEGRATION:-true}
 RHDH_GITLAB_INTEGRATION=${RHDH_GITLAB_INTEGRATION:-false}
 RHDH_SIGNIN_PROVIDER=${RHDH_SIGNIN_PROVIDER:-''}
+RHDH_DISABLE_AUTH_POLICY=${RHDH_DISABLE_AUTH_POLICY:-false}
 
 # Secret variables
 GITHUB__APP__ID=${GITHUB__APP__ID:-''}
@@ -364,8 +365,8 @@ if [[ $LIGHTSPEED_INTEGRATION == "true" ]]; then
     fi
     echo -n "."
 fi
-# Only use for running end-to-end tests in CI, keep away from production
-if [[ $CI_DISABLE_AUTH == "true" ]]; then
+# Only use for testing purposes, etc. Keep away from production
+if [[ $RHDH_DISABLE_AUTH_POLICY == "true" ]]; then
     EXTRA_APPCONFIG=$(echo "$EXTRA_APPCONFIG" | yq ".backend.auth.dangerouslyDisableDefaultAuthPolicy = true" -M -)
     echo -n "."
 fi


### PR DESCRIPTION
### What does this PR do?:
Adds the option to disable API auth to be used **for testing in CI only** using the `CI_DISABLE_AUTH` env variable.

This approach is taken from [RHTAP](https://github.com/redhat-appstudio/rhtap-cli/blob/9784e3b54f1517ace5c1f89122e2dd68bbf0f54f/installer/charts/rhtap-dh/templates/app-config-content.yaml#L67), allows the tests to run templates through unauthenticated API requests. 

### Which issue(s) this PR fixes:
https://issues.redhat.com/browse/RHDHPAI-591

### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened and linked to this PR, if they are not in the PR scope due to various constraints.

- [x] Tested and Verified

  <!-- _I have verified that the changes were tested manually_ -->

- [ ] Documentation (READMEs, Product Docs, Blogs, Education Modules, etc.)

   <!-- _This includes READMEs, Product Docs, Blogs, Education Modules, etc._ -->


### How to test changes / Special notes to the reviewer:
