### PR TITLE
[RHDHPAI-567] Add Auto-Disabling of TLS Check After Multiple Failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ You can pass the `skip-test-tls` value as a flag in your Helm upgrade command as
 helm upgrade --install ai-rhdh ./chart --namespace ai-rhdh --create-namespace --set openshift-gitops.skip-test-tls=true
 ```
 
+**Note:** If you have `skip-test-tls` set to `false` and the install script encounters the `context deadline exceeded` error **5** times it will automatically try to skip the TLS check.
+
 ## Configuration
 
 > [!IMPORTANT] 

--- a/README.md
+++ b/README.md
@@ -59,8 +59,6 @@ You can pass the `skip-test-tls` value as a flag in your Helm upgrade command as
 helm upgrade --install ai-rhdh ./chart --namespace ai-rhdh --create-namespace --set openshift-gitops.skip-test-tls=true
 ```
 
-**Note:** If you have `skip-test-tls` set to `false` and the install script encounters the `context deadline exceeded` error **5** times it will automatically try to skip the TLS check.
-
 ## Configuration
 
 > [!IMPORTANT] 

--- a/chart/templates/openshift-gitops/includes/_configure.tpl
+++ b/chart/templates/openshift-gitops/includes/_configure.tpl
@@ -71,7 +71,7 @@
 
           echo "* Logging Into ArgoCD *"
           while (( RETRY < MAX_RETRY )); do
-            attempt_result=$(./argocd login "$ARGOCD_HOSTNAME" --loglevel debug --grpc-web --insecure --http-retry-max 10 --username admin --password "$ARGOCD_PASSWORD"{{- if eq (index .Values "openshift-gitops" "skip-test-tls") true }} --skip-test-tls{{- end }} 2>&1)
+            attempt_result=$(./argocd login "$ARGOCD_HOSTNAME" --grpc-web --insecure --http-retry-max 10 --username admin --password "$ARGOCD_PASSWORD"{{- if eq (index .Values "openshift-gitops" "skip-test-tls") true }} --skip-test-tls{{- end }} 2>&1)
             exit_code=$?
 
             if [[ $exit_code -eq 0 ]]; then

--- a/chart/templates/openshift-gitops/includes/_configure.tpl
+++ b/chart/templates/openshift-gitops/includes/_configure.tpl
@@ -6,17 +6,17 @@
     - /bin/sh
     - -c
     - |
-      set -o errexit
       set -o nounset
       set -o pipefail
 
-      echo -n "* Installing 'argocd' CLI: "
+      echo "* Installing ArgoCD CLI *"
       curl -sSL -o argocd https://github.com/argoproj/argo-cd/releases/latest/download/argocd-linux-amd64
       chmod 555 argocd
+      echo -n "ArgoCD CLI version: "
       ./argocd version --client | head -1 | cut -d' ' -f2
 
       CRD="argocds"
-      echo -n "* Waiting for '$CRD' CRD: "
+      echo "* Waiting for '$CRD' CRD *"
       while [ $(kubectl api-resources | grep -c "^$CRD ") = "0" ] ; do
         echo -n "."
         sleep 3
@@ -30,46 +30,100 @@
       NAMESPACE="{{.Release.Namespace}}"
       RHDH_ARGOCD_INSTANCE="$CHART-argocd"
 
-      echo -n "* Waiting for gitops operator deployment: "
+      echo "* Waiting for Gitops Operator Deployment *"
       until kubectl get argocds.argoproj.io -n openshift-gitops openshift-gitops -o jsonpath={.status.phase} | grep -q "^Available$"; do
-        echo -n "_"
+        echo -n "."
         sleep 2
       done
       echo "OK"
 
-      echo -n "* Creating ArgoCD instance: "
+      echo "* Creating ArgoCD Instance *"
       cat <<EOF | kubectl apply -n "$NAMESPACE" -f - >/dev/null
       {{ include "rhdh.include.argocd" . | indent 6 }}
       EOF
+      echo "... Waiting for ArgoCD Instance"
       until kubectl get argocds.argoproj.io -n "$NAMESPACE" "ai-$RHDH_ARGOCD_INSTANCE" --ignore-not-found -o jsonpath={.status.phase} | grep -q "^Available$"; do
-        echo -n "_"
+        echo -n "."
         sleep 2
       done
-      echo -n "."
+      echo "OK"
+      echo "... Fetching ArgoCD Instance Route"
       until kubectl get route -n "$NAMESPACE" "ai-$RHDH_ARGOCD_INSTANCE-server" >/dev/null 2>&1; do
-        echo -n "_"
+        echo -n "."
         sleep 2
       done
       echo "OK"
 
-      echo -n "* ArgoCD admin user: "
+      echo "* Updating ArgoCD Admin User *"
       if [ "$(kubectl get secret "$RHDH_ARGOCD_INSTANCE-secret" -o name --ignore-not-found | wc -l)" = "0" ]; then
+          echo "... Fetching ArgoCD Hostname"
           ARGOCD_HOSTNAME="$(kubectl get route -n "$NAMESPACE" "ai-$RHDH_ARGOCD_INSTANCE-server" --ignore-not-found -o jsonpath={.spec.host})"
-          echo -n "."
+          echo "OK"
+          echo "... Fetching ArgoCD Password"
           ARGOCD_PASSWORD="$(kubectl get secret -n "$NAMESPACE" "ai-$RHDH_ARGOCD_INSTANCE-cluster" -o jsonpath="{.data.admin\.password}" | base64 --decode)"
-          echo -n "."
+          echo "OK"
+          
           RETRY=0
-          while ! ./argocd login "$ARGOCD_HOSTNAME" --grpc-web --insecure --http-retry-max 5 --username admin --password "$ARGOCD_PASSWORD"{{- if eq (index .Values "openshift-gitops" "skip-test-tls") true }} --skip-test-tls{{- end }}>/dev/null; do
-            if [ "$RETRY" = "20" ]; then
-              echo "FAIL"
-              echo "[ERROR] Could not login to ArgoCD" >&2
-              exit 1
-            else
-              echo -n "_"
-              RETRY=$((RETRY + 1))
-              sleep 5
+          MAX_RETRY=20
+          deadline_exceeded_tries=0
+          max_deadline_exceeded_tries=5
+          deadline_exceeded_thrown=0
+
+          echo "* Logging Into ArgoCD *"
+          while (( RETRY < MAX_RETRY )); do
+            attempt_result=$(./argocd login "$ARGOCD_HOSTNAME" --loglevel debug --grpc-web --insecure --http-retry-max 10 --username admin --password "$ARGOCD_PASSWORD"{{- if eq (index .Values "openshift-gitops" "skip-test-tls") true }} --skip-test-tls{{- end }} 2>&1)
+            exit_code=$?
+
+            if [[ $exit_code -eq 0 ]]; then
+              echo "Successfully logged in to ArgoCD."
+              break
             fi
+
+            if echo "$attempt_result" | grep -q "context deadline exceeded"; then
+              deadline_exceeded_tries=$((deadline_exceeded_tries + 1))
+              if (( deadline_exceeded_tries == max_deadline_exceeded_tries )); then
+                deadline_exceeded_thrown=1
+                break
+              fi
+              echo "Context deadline exceeded thrown $deadline_exceeded_tries time(s). Retrying .." 
+            else
+              echo -n "."
+            fi
+
+            RETRY=$((RETRY + 1))
+            sleep 5
           done
+
+          if [[ "$RETRY" -eq "$MAX_RETRY" ]]; then
+            echo "FAIL"
+            echo "[ERROR] Could not login to  ArgoCD, retry limit reached." >&2
+            exit 1
+          fi
+
+          if (( deadline_exceeded_thrown )); then
+            echo "ArgoCD login experiencing 'context deadline exceeded error', auto applying '--skip-test-tls' flag."
+            deadline_exceeded_tries=0
+            while (( deadline_exceeded_tries < max_deadline_exceeded_tries )); do
+              attempt_result=$(./argocd login "$ARGOCD_HOSTNAME" --grpc-web --insecure --http-retry-max 10 --username admin --password "$ARGOCD_PASSWORD" --skip-test-tls 2>&1)
+              exit_code=$?
+
+              if [[ $exit_code -eq 0 ]]; then
+                echo "Successfully logged in to ArgoCD."
+                break
+              fi
+
+              echo -n "."
+              deadline_exceeded_tries=$((deadline_exceeded_tries + 1))
+              sleep 5
+            done
+          fi
+
+          if [[ "$deadline_exceeded_tries" -eq "$max_deadline_exceeded_tries" ]]; then
+            echo "FAIL"
+            echo "[ERROR] Could not login to  ArgoCD, retry limit reached." >&2
+            exit 1
+          fi
+
           echo -n "."
           ARGOCD_API_TOKEN="$(./argocd account generate-token --http-retry-max 5 --account "admin")"
           echo -n "."


### PR DESCRIPTION
### What does this PR do?:
<!-- _Summarize the changes_ -->

This PR contains the following changes:

- Adds retry limit for encountering the `context deadline exceeded` error, after 5 attempts it will add the `--skip-test-tls` flag to the ArgoCD login.
    - Had to remove the `-e` flag from the script to enable the manual handling of this error.
- Refactors the logging output for the Gitops configuration for more readability/consistency.
- Updates README documentation to reflect this new change.

### Which issue(s) this PR fixes:
<!-- _Link to Github/JIRA issue(s)_ -->

https://issues.redhat.com/browse/RHDHPAI-567

### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened and linked to this PR, if they are not in the PR scope due to various constraints.

- [x] Tested and Verified

  <!-- _I have verified that the changes were tested manually_ -->

- [x] Documentation (READMEs, Product Docs, Blogs, Education Modules, etc.)

   <!-- _This includes READMEs, Product Docs, Blogs, Education Modules, etc._ -->


### How to test changes / Special notes to the reviewer:
I was able to get the Gitops configuration to run properly after deploying Helm with both the `skip-test-tls` set to `false` and having it hit the auto-enable, as well as having `skip-test-tls` set to `true` and having it work properly the first time.