### PR TITLE
[RHDHPAI-523] Add Flag To Prevent Helm Uninstall Crash Loop

### DIFF
--- a/chart/templates/developer-hub/includes/_unconfigure.tpl
+++ b/chart/templates/developer-hub/includes/_unconfigure.tpl
@@ -17,25 +17,25 @@
       NAMESPACE="{{.Release.Namespace}}"
 
       echo -n "* Deleting RHDH instance: "
-      cat <<EOF | kubectl delete -n "$NAMESPACE" -f - >/dev/null
+      cat <<EOF | kubectl delete -n "$NAMESPACE" --ignore-not-found -f - >/dev/null
       {{ include "rhdh.include.backstage" . | indent 6 }}
       EOF
       echo "OK"
 
       echo -n "* Deleting RHDH Dynamic Plugins Config: "
-      cat <<EOF | kubectl delete -f - >/dev/null
+      cat <<EOF | kubectl delete --ignore-not-found -f - >/dev/null
       {{ include "rhdh.include.plugins" . | indent 6 }}
       EOF
       echo "OK"
 
       echo -n "* Deleting RHDH Base App Config: "
-      cat <<EOF | kubectl delete -f - >/dev/null
+      cat <<EOF | kubectl delete --ignore-not-found -f - >/dev/null
       {{ include "rhdh.include.appconfig" . | indent 6 }}
       EOF
       echo "OK"
 
       echo -n "* Deleting RHDH Extra Variables Secret: "
-      cat <<EOF | kubectl delete -f - >/dev/null
+      cat <<EOF | kubectl delete --ignore-not-found -f - >/dev/null
       {{ include "rhdh.include.extra-env" . | indent 6 }}
       EOF
       echo "OK"

--- a/chart/templates/openshift-gitops/includes/_unconfigure.tpl
+++ b/chart/templates/openshift-gitops/includes/_unconfigure.tpl
@@ -18,12 +18,12 @@
       RHDH_ARGOCD_INSTANCE="$CHART-argocd"
 
       echo -n "* Deleting ArgoCD instance: "
-      cat <<EOF | kubectl delete -n "$NAMESPACE" -f - >/dev/null
+      cat <<EOF | kubectl delete -n "$NAMESPACE" --ignore-not-found -f - >/dev/null
       {{ include "rhdh.include.argocd" . | indent 6 }}
       EOF
       echo "OK"
 
       echo -n "* Deleting ArgoCD secret: "
-      kubectl delete secret "$RHDH_ARGOCD_INSTANCE-secret" >/dev/null
+      kubectl delete secret "$RHDH_ARGOCD_INSTANCE-secret" --ignore-not-found >/dev/null
       echo "OK"
 {{ end }}


### PR DESCRIPTION
### What does this PR do?:
<!-- _Summarize the changes_ -->


This PR adds the `--ignore-not-found` flag to `kubectl delete` which allows the command to handle non-existent resources as successful deletions. This should eliminate the crash loop that is occurring during `Helm uninstall` where the resources are partially installed as the script won't error out if a resource is missing.


### Which issue(s) this PR fixes:
<!-- _Link to Github/JIRA issue(s)_ -->

https://issues.redhat.com/browse/RHDHPAI-523

### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened and linked to this PR, if they are not in the PR scope due to various constraints.

- [ ] Tested and Verified

  <!-- _I have verified that the changes were tested manually_ -->

- [ ] Documentation (READMEs, Product Docs, Blogs, Education Modules, etc.)

   <!-- _This includes READMEs, Product Docs, Blogs, Education Modules, etc._ -->


### How to test changes / Special notes to the reviewer:
Was having issues reproducing using the steps outlined in the linked JIRA above so to work around this I had to allow the install to complete and then manually go in and remove one of the resources (app configmag, env secret, etc) so that something was "missing/partial" before running the uninstall portion.

If anyone was able to properly reproduce with the instructions in JIRA and can let me know how this fix handles it I would very much appreciate that.