### PR TITLE
Migrate deprecated field `replicas` for RHDH v1.3+

### DIFF
--- a/chart/templates/developer-hub/includes/_backstage.tpl
+++ b/chart/templates/developer-hub/includes/_backstage.tpl
@@ -1,13 +1,12 @@
 {{ define "rhdh.include.backstage" }}
 ---
-apiVersion: rhdh.redhat.com/v1alpha1
+apiVersion: rhdh.redhat.com/v1alpha2
 kind: Backstage
 metadata:
   name: ai-rh-developer-hub
   namespace: {{ .Release.Namespace }}
 spec:
   application:
-    replicas: 1
     route:
       enabled: true
     extraEnvs:
@@ -19,4 +18,8 @@ spec:
     dynamicPluginsConfigMapName: dynamic-plugins
   database:
     enableLocalDb: true
+  deployment:
+    patch:
+      spec: 
+        replicas: 1
 {{ end }}


### PR DESCRIPTION
### What does this PR do?:
<!-- _Summarize the changes_ -->

Removes the deprecated field `.spec.application.replicas` in favour of new `.spec.deployment.patch.spec.replicas` to replace it.

### Which issue(s) this PR fixes:
<!-- _Link to Github/JIRA issue(s)_ -->

https://issues.redhat.com/browse/RHDHPAI-583

### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened and linked to this PR, if they are not in the PR scope due to various constraints.

- [X] Tested and Verified

  <!-- _I have verified that the changes were tested manually_ -->

- [ ] Documentation (READMEs, Product Docs, Blogs, Education Modules, etc.)

   <!-- _This includes READMEs, Product Docs, Blogs, Education Modules, etc._ -->


### How to test changes / Special notes to the reviewer:

Follow install steps under the [README](README).

