### PR TITLE
[RHDHPAI-587] Kubernetes Service Account Name + Token Name Override

### DIFF
--- a/docs/rhdh/PRE-EXISTING.md
+++ b/docs/rhdh/PRE-EXISTING.md
@@ -91,9 +91,11 @@ You will need to create a Secret to store all the private environment variables 
 ```sh
 K8S_SA_SECRET_NAME=$(kubectl get secrets -n "$NAMESPACE" -o name | grep "$KUBERNETES_SA_TOKEN_SECRET" | cut -d/ -f2 | head -1)
 K8S_SA_TOKEN=$(kubectl -n $NAMESPACE get secret $K8S_SA_SECRET_NAME -o yaml | yq '.data.token' -M -I=0)
+KUBERNETES_SA_ENCODED=$(echo -n "$KUBERNETES_SA" | base64 -w 0)
 kubectl -n $NAMESPACE create secret generic ai-rh-developer-hub-env \
     --from-literal=NODE_TLS_REJECT_UNAUTHORIZED=$(echo "0" | base64) \
-    --from-literal=K8S_SA_TOKEN=${K8S_SA_TOKEN}
+    --from-literal=K8S_SA_TOKEN=${K8S_SA_TOKEN} \
+    --from-literal=K8S_SA=${KUBERNETES_SA_ENCODED}
 ```
 
 **GitHub**
@@ -101,6 +103,7 @@ kubectl -n $NAMESPACE create secret generic ai-rh-developer-hub-env \
 ```sh
 K8S_SA_SECRET_NAME=$(kubectl get secrets -n "$NAMESPACE" -o name | grep "$KUBERNETES_SA_TOKEN_SECRET" | cut -d/ -f2 | head -1)
 K8S_SA_TOKEN=$(kubectl -n $NAMESPACE get secret $K8S_SA_SECRET_NAME -o yaml | yq '.data.token' -M -I=0)
+KUBERNETES_SA_ENCODED=$(echo -n "$KUBERNETES_SA" | base64 -w 0)
 kubectl -n $NAMESPACE create secret generic ai-rh-developer-hub-env \
     --from-literal=NODE_TLS_REJECT_UNAUTHORIZED=$(echo "0" | base64) \
     --from-literal=K8S_SA_TOKEN=${K8S_SA_TOKEN} \
@@ -111,7 +114,8 @@ kubectl -n $NAMESPACE create secret generic ai-rh-developer-hub-env \
     --from-literal=GITHUB__APP__WEBHOOK__SECRET=$(echo '<github_app_webhook_secret>' | base64) \
     --from-file=GITHUB__APP__PRIVATE_KEY='<path-to-app-pk>' \
     --from-literal=GITHUB__ORG__NAME=$(echo '<github_org_name>' | base64) \
-    --from-literal=GITOPS__GIT_TOKEN=$(echo '<git_pat>' | base64)
+    --from-literal=GITOPS__GIT_TOKEN=$(echo '<git_pat>' | base64) \
+    --from-literal=K8S_SA=${KUBERNETES_SA_ENCODED}
 ```
 
 **GitHub Enterprise**
@@ -119,6 +123,7 @@ kubectl -n $NAMESPACE create secret generic ai-rh-developer-hub-env \
 ```sh
 K8S_SA_SECRET_NAME=$(kubectl get secrets -n "$NAMESPACE" -o name | grep "$KUBERNETES_SA_TOKEN_SECRET" | cut -d/ -f2 | head -1)
 K8S_SA_TOKEN=$(kubectl -n $NAMESPACE get secret $K8S_SA_SECRET_NAME -o yaml | yq '.data.token' -M -I=0)
+KUBERNETES_SA_ENCODED=$(echo -n "$KUBERNETES_SA" | base64 -w 0)
 kubectl -n $NAMESPACE create secret generic ai-rh-developer-hub-env \
     --from-literal=NODE_TLS_REJECT_UNAUTHORIZED=$(echo "0" | base64) \
     --from-literal=K8S_SA_TOKEN=${K8S_SA_TOKEN} \
@@ -130,7 +135,8 @@ kubectl -n $NAMESPACE create secret generic ai-rh-developer-hub-env \
     --from-file=GITHUB__APP__PRIVATE_KEY='<path-to-app-pk>' \
     --from-literal=GITHUB__HOST=$(echo '<github_hostname>' | base64) \
     --from-literal=GITHUB__ORG__NAME=$(echo '<github_org_name>' | base64) \
-    --from-literal=GITOPS__GIT_TOKEN=$(echo '<git_pat>' | base64)
+    --from-literal=GITOPS__GIT_TOKEN=$(echo '<git_pat>' | base64) \
+    --from-literal=K8S_SA=${KUBERNETES_SA_ENCODED}
 ```
 
 **GitLab**
@@ -138,12 +144,14 @@ kubectl -n $NAMESPACE create secret generic ai-rh-developer-hub-env \
 ```sh
 K8S_SA_SECRET_NAME=$(kubectl get secrets -n "$NAMESPACE" -o name | grep "$KUBERNETES_SA_TOKEN_SECRET" | cut -d/ -f2 | head -1)
 K8S_SA_TOKEN=$(kubectl -n $NAMESPACE get secret $K8S_SA_SECRET_NAME -o yaml | yq '.data.token' -M -I=0)
+KUBERNETES_SA_ENCODED=$(echo -n "$KUBERNETES_SA" | base64 -w 0)
 kubectl -n $NAMESPACE create secret generic ai-rh-developer-hub-env \
     --from-literal=NODE_TLS_REJECT_UNAUTHORIZED=$(echo "0" | base64) \
     --from-literal=K8S_SA_TOKEN=${K8S_SA_TOKEN} \
     --from-literal=GITLAB__APP__CLIENT__ID=$(echo '<gitlab_app_client_id>' | base64) \
     --from-literal=GITLAB__APP__CLIENT__SECRET=$(echo '<gitlab_app_client_secret>' | base64) \
-    --from-literal=GITLAB__TOKEN=$(echo '<gitlab_pat>' | base64)
+    --from-literal=GITLAB__TOKEN=$(echo '<gitlab_pat>' | base64) \
+    --from-literal=K8S_SA=${KUBERNETES_SA_ENCODED}
 ```
 
 **GitLab Self-hosted**
@@ -151,13 +159,15 @@ kubectl -n $NAMESPACE create secret generic ai-rh-developer-hub-env \
 ```sh
 K8S_SA_SECRET_NAME=$(kubectl get secrets -n "$NAMESPACE" -o name | grep "$KUBERNETES_SA_TOKEN_SECRET" | cut -d/ -f2 | head -1)
 K8S_SA_TOKEN=$(kubectl -n $NAMESPACE get secret $K8S_SA_SECRET_NAME -o yaml | yq '.data.token' -M -I=0)
+KUBERNETES_SA_ENCODED=$(echo -n "$KUBERNETES_SA" | base64 -w 0)
 kubectl -n $NAMESPACE create secret generic ai-rh-developer-hub-env \
     --from-literal=NODE_TLS_REJECT_UNAUTHORIZED=$(echo "0" | base64) \
     --from-literal=K8S_SA_TOKEN=${K8S_SA_TOKEN} \
     --from-literal=GITLAB__APP__CLIENT__ID=$(echo '<gitlab_app_client_id>' | base64) \
     --from-literal=GITLAB__APP__CLIENT__SECRET=$(echo '<gitlab_app_client_secret>' | base64) \
     --from-literal=GITLAB__TOKEN=$(echo '<gitlab_pat>' | base64) \
-    --from-literal=GITLAB__HOST=$(echo '<gitlab_hostname>' | base64)
+    --from-literal=GITLAB__HOST=$(echo '<gitlab_hostname>' | base64) \
+    --from-literal=K8S_SA=${KUBERNETES_SA_ENCODED}
 ```
 
 **GitHub & GitLab**
@@ -165,6 +175,7 @@ kubectl -n $NAMESPACE create secret generic ai-rh-developer-hub-env \
 ```sh
 K8S_SA_SECRET_NAME=$(kubectl get secrets -n "$NAMESPACE" -o name | grep "$KUBERNETES_SA_TOKEN_SECRET" | cut -d/ -f2 | head -1)
 K8S_SA_TOKEN=$(kubectl -n $NAMESPACE get secret $K8S_SA_SECRET_NAME -o yaml | yq '.data.token' -M -I=0)
+KUBERNETES_SA_ENCODED=$(echo -n "$KUBERNETES_SA" | base64 -w 0)
 kubectl -n $NAMESPACE create secret generic ai-rh-developer-hub-env \
     --from-literal=NODE_TLS_REJECT_UNAUTHORIZED=$(echo "0" | base64) \
     --from-literal=K8S_SA_TOKEN=${K8S_SA_TOKEN} \
@@ -178,7 +189,8 @@ kubectl -n $NAMESPACE create secret generic ai-rh-developer-hub-env \
     --from-literal=GITOPS__GIT_TOKEN=$(echo '<git_pat>' | base64) \
     --from-literal=GITLAB__APP__CLIENT__ID=$(echo '<gitlab_app_client_id>' | base64) \
     --from-literal=GITLAB__APP__CLIENT__SECRET=$(echo '<gitlab_app_client_secret>' | base64) \
-    --from-literal=GITLAB__TOKEN=$(echo '<gitlab_pat>' | base64)
+    --from-literal=GITLAB__TOKEN=$(echo '<gitlab_pat>' | base64) \
+    --from-literal=K8S_SA=${KUBERNETES_SA_ENCODED}
 ```
 
 Notice that `K8S_SA_TOKEN` does not need encoding as the other literal sets, this is because when the value is fetched from the Service Account Token Secret it comes back already encoded.

--- a/docs/rhdh/PRE-EXISTING.md
+++ b/docs/rhdh/PRE-EXISTING.md
@@ -71,16 +71,25 @@ Once you have done the prior steps and have the information from the prior steps
 
 You can skip this step if these resources are already present in your desired namespace.
 
+**Note:** If the resources are already present in your desired namespace, you will need to ensure that `$KUBERNETES_SA` and `$KUBERNETES_SA_TOKEN_SECRET` environment variables are set to the correct values.
+
+```
+export KUBERNETES_SA=<your-sa-name>
+export KUBERNETES_SA_TOKEN_SECRET=<your-secret-name>
+```
+
 For information related to creating these resources see [`KUBERNETES_SERVICEACCOUNT.md`](../pipelines/KUBERNETES_SERVICEACCOUNT.md).
 
 #### Step 2: Create Extra Environment Variables Secret
+
+**Note:** The following commands assume that `export KUBERNETES_SA_TOKEN_SECRET=<your-secret-name>` and `export KUBERNETES_SA=<your-sa-name>` were run.
 
 You will need to create a Secret to store all the private environment variables for RHDH. This can be done one of the following ways:
 
 **No Integration**
 
 ```sh
-K8S_SA_SECRET_NAME=$(kubectl get secrets -n "$NAMESPACE" -o name | grep rhdh-kubernetes-plugin-token | cut -d/ -f2 | head -1)
+K8S_SA_SECRET_NAME=$(kubectl get secrets -n "$NAMESPACE" -o name | grep "$KUBERNETES_SA_TOKEN_SECRET" | cut -d/ -f2 | head -1)
 K8S_SA_TOKEN=$(kubectl -n $NAMESPACE get secret $K8S_SA_SECRET_NAME -o yaml | yq '.data.token' -M -I=0)
 kubectl -n $NAMESPACE create secret generic ai-rh-developer-hub-env \
     --from-literal=NODE_TLS_REJECT_UNAUTHORIZED=$(echo "0" | base64) \
@@ -90,7 +99,7 @@ kubectl -n $NAMESPACE create secret generic ai-rh-developer-hub-env \
 **GitHub**
 
 ```sh
-K8S_SA_SECRET_NAME=$(kubectl get secrets -n "$NAMESPACE" -o name | grep rhdh-kubernetes-plugin-token | cut -d/ -f2 | head -1)
+K8S_SA_SECRET_NAME=$(kubectl get secrets -n "$NAMESPACE" -o name | grep "$KUBERNETES_SA_TOKEN_SECRET" | cut -d/ -f2 | head -1)
 K8S_SA_TOKEN=$(kubectl -n $NAMESPACE get secret $K8S_SA_SECRET_NAME -o yaml | yq '.data.token' -M -I=0)
 kubectl -n $NAMESPACE create secret generic ai-rh-developer-hub-env \
     --from-literal=NODE_TLS_REJECT_UNAUTHORIZED=$(echo "0" | base64) \
@@ -108,7 +117,7 @@ kubectl -n $NAMESPACE create secret generic ai-rh-developer-hub-env \
 **GitHub Enterprise**
 
 ```sh
-K8S_SA_SECRET_NAME=$(kubectl get secrets -n "$NAMESPACE" -o name | grep rhdh-kubernetes-plugin-token | cut -d/ -f2 | head -1)
+K8S_SA_SECRET_NAME=$(kubectl get secrets -n "$NAMESPACE" -o name | grep "$KUBERNETES_SA_TOKEN_SECRET" | cut -d/ -f2 | head -1)
 K8S_SA_TOKEN=$(kubectl -n $NAMESPACE get secret $K8S_SA_SECRET_NAME -o yaml | yq '.data.token' -M -I=0)
 kubectl -n $NAMESPACE create secret generic ai-rh-developer-hub-env \
     --from-literal=NODE_TLS_REJECT_UNAUTHORIZED=$(echo "0" | base64) \
@@ -127,7 +136,7 @@ kubectl -n $NAMESPACE create secret generic ai-rh-developer-hub-env \
 **GitLab**
 
 ```sh
-K8S_SA_SECRET_NAME=$(kubectl get secrets -n "$NAMESPACE" -o name | grep rhdh-kubernetes-plugin-token | cut -d/ -f2 | head -1)
+K8S_SA_SECRET_NAME=$(kubectl get secrets -n "$NAMESPACE" -o name | grep "$KUBERNETES_SA_TOKEN_SECRET" | cut -d/ -f2 | head -1)
 K8S_SA_TOKEN=$(kubectl -n $NAMESPACE get secret $K8S_SA_SECRET_NAME -o yaml | yq '.data.token' -M -I=0)
 kubectl -n $NAMESPACE create secret generic ai-rh-developer-hub-env \
     --from-literal=NODE_TLS_REJECT_UNAUTHORIZED=$(echo "0" | base64) \
@@ -140,7 +149,7 @@ kubectl -n $NAMESPACE create secret generic ai-rh-developer-hub-env \
 **GitLab Self-hosted**
 
 ```sh
-K8S_SA_SECRET_NAME=$(kubectl get secrets -n "$NAMESPACE" -o name | grep rhdh-kubernetes-plugin-token | cut -d/ -f2 | head -1)
+K8S_SA_SECRET_NAME=$(kubectl get secrets -n "$NAMESPACE" -o name | grep "$KUBERNETES_SA_TOKEN_SECRET" | cut -d/ -f2 | head -1)
 K8S_SA_TOKEN=$(kubectl -n $NAMESPACE get secret $K8S_SA_SECRET_NAME -o yaml | yq '.data.token' -M -I=0)
 kubectl -n $NAMESPACE create secret generic ai-rh-developer-hub-env \
     --from-literal=NODE_TLS_REJECT_UNAUTHORIZED=$(echo "0" | base64) \
@@ -154,7 +163,7 @@ kubectl -n $NAMESPACE create secret generic ai-rh-developer-hub-env \
 **GitHub & GitLab**
 
 ```sh
-K8S_SA_SECRET_NAME=$(kubectl get secrets -n "$NAMESPACE" -o name | grep rhdh-kubernetes-plugin-token | cut -d/ -f2 | head -1)
+K8S_SA_SECRET_NAME=$(kubectl get secrets -n "$NAMESPACE" -o name | grep "$KUBERNETES_SA_TOKEN_SECRET" | cut -d/ -f2 | head -1)
 K8S_SA_TOKEN=$(kubectl -n $NAMESPACE get secret $K8S_SA_SECRET_NAME -o yaml | yq '.data.token' -M -I=0)
 kubectl -n $NAMESPACE create secret generic ai-rh-developer-hub-env \
     --from-literal=NODE_TLS_REJECT_UNAUTHORIZED=$(echo "0" | base64) \

--- a/dynamic-plugins/tekton-plugins.yaml
+++ b/dynamic-plugins/tekton-plugins.yaml
@@ -26,7 +26,7 @@ plugins:
         clusterLocatorMethods:
           - clusters:
               - authProvider: serviceAccount
-                name: rhdh-kubernetes-plugin
+                name: ${K8S_SA}
                 serviceAccountToken: ${K8S_SA_TOKEN}
                 skipTLSVerify: true
                 url: https://kubernetes.default.svc

--- a/scripts/configure-dh.sh
+++ b/scripts/configure-dh.sh
@@ -44,6 +44,8 @@ QUAY__DOCKERCONFIGJSON=${QUAY__DOCKERCONFIGJSON:-''}
 QUAY__API_TOKEN=${QUAY__API_TOKEN:-''}
 LIGHTSPEED_MODEL_URL=${LIGHTSPEED_MODEL_URL:-''}
 LIGHTSPEED_API_TOKEN=${LIGHTSPEED_API_TOKEN:-''}
+KUBERNETES_SA=${KUBERNETES_SA:-'rhdh-kubernetes-plugin'}
+KUBERNETES_SA_TOKEN_SECRET=${KUBERNETES_SA_TOKEN_SECRET:-'rhdh-kubernetes-plugin-token'}
 
 signin_provider=''
 # Use existing variables if RHDH instance is provided
@@ -452,20 +454,21 @@ fi
 
 # Add Tekton information and plugin to backstage deployment data
 echo -n "* Adding Tekton information and plugin to backstage deployment data: "
-K8S_SA_SECRET_NAME=$(kubectl get secrets -n "$NAMESPACE" -o name | grep rhdh-kubernetes-plugin-token | cut -d/ -f2 | head -1)
+K8S_SA_SECRET=$(kubectl get secrets -n "$NAMESPACE" -o name | grep "$KUBERNETES_SA_TOKEN_SECRET" | cut -d/ -f2 | head -1)
 if [ $? -ne 0 ]; then
     echo "FAIL"
     exit 1
 fi
 if [[ $RHDH_INSTANCE_PROVIDED == "true" ]]; then
     kubectl get deploy $RHDH_DEPLOYMENT -n $NAMESPACE -o yaml | \
-        yq ".spec.template.spec.containers[0].env += {\"name\": \"K8S_SA_TOKEN\", \"valueFrom\": {\"secretKeyRef\": {\"name\": \"${K8S_SA_SECRET_NAME}\", \"key\": \"token\"}}} | 
+        yq ".spec.template.spec.containers[0].env += {\"name\": \"K8S_SA_TOKEN\", \"valueFrom\": {\"secretKeyRef\": {\"name\": \"${K8S_SA_SECRET}\", \"key\": \"token\"}}} | 
+        .spec.template.spec.containers[0].env += {\"name\": \"K8S_SA\", \"valueFrom\": {\"secretKeyRef\": {\"name\": \"${KUBERNETES_SA}\", \"key\": \"token\"}}} |
         .spec.template.spec.containers[0].env |= unique_by(.name)" | \
         kubectl apply -f - >/dev/null
 else
-    K8S_SA_TOKEN=$(kubectl -n $NAMESPACE get secret $K8S_SA_SECRET_NAME -o yaml | yq '.data.token' -M -I=0)
+    K8S_SA_TOKEN=$(kubectl -n $NAMESPACE get secret $K8S_SA_SECRET -o yaml | yq '.data.token' -M -I=0)
     
-    kubectl -n $NAMESPACE get secret $RHDH_EXTRA_ENV_SECRET -o yaml | yq ".data.K8S_SA_TOKEN = \"${K8S_SA_TOKEN}\"" -M -I=0 | \
+    kubectl -n $NAMESPACE get secret $RHDH_EXTRA_ENV_SECRET -o yaml | yq ".data.K8S_SA = \"${KUBERNETES_SA}\"" | yq ".data.K8S_SA_TOKEN = \"${K8S_SA_TOKEN}\"" -M -I=0 | \
         kubectl apply -n $NAMESPACE -f - >/dev/null
 fi
 if [ $? -ne 0 ]; then

--- a/scripts/configure-dh.sh
+++ b/scripts/configure-dh.sh
@@ -467,8 +467,8 @@ if [[ $RHDH_INSTANCE_PROVIDED == "true" ]]; then
         kubectl apply -f - >/dev/null
 else
     K8S_SA_TOKEN=$(kubectl -n $NAMESPACE get secret $K8S_SA_SECRET -o yaml | yq '.data.token' -M -I=0)
-    
-    kubectl -n $NAMESPACE get secret $RHDH_EXTRA_ENV_SECRET -o yaml | yq ".data.K8S_SA = \"${KUBERNETES_SA}\"" | yq ".data.K8S_SA_TOKEN = \"${K8S_SA_TOKEN}\"" -M -I=0 | \
+    KUBERNETES_SA_ENCODED=$(echo -n "$KUBERNETES_SA" | base64 -w 0)
+    kubectl -n $NAMESPACE get secret $RHDH_EXTRA_ENV_SECRET -o yaml | yq ".data.K8S_SA = \"${KUBERNETES_SA_ENCODED}\" | .data.K8S_SA_TOKEN = \"${K8S_SA_TOKEN}\"" -M -I=0 | \
         kubectl apply -n $NAMESPACE -f - >/dev/null
 fi
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
### What does this PR do?:
<!-- _Summarize the changes_ -->

This PR adds the option to override the Kubernetes Service Account name and token Secret name if you already have them setup on a cluster for pre-existing instances. Before this change the installer was assuming a consistent naming pattern that may not be true for all cases.

### Which issue(s) this PR fixes:
<!-- _Link to Github/JIRA issue(s)_ -->

https://issues.redhat.com/browse/RHDHPAI-587

### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened and linked to this PR, if they are not in the PR scope due to various constraints.

- [x] Tested and Verified

  <!-- _I have verified that the changes were tested manually_ -->

- [x] Documentation (READMEs, Product Docs, Blogs, Education Modules, etc.)

   <!-- _This includes READMEs, Product Docs, Blogs, Education Modules, etc._ -->


### How to test changes / Special notes to the reviewer:
To test you can run the following 2 scenarios:

**1**
Run the installer normally and observe the K8S SA being used correctly in RHDH.

**2**
Alter the name of the K8S SA and Token in the Helm resources so it installs with a name differing from the default, then set the env vars and observe the SA being used correctly in RHDH.