### PR TITLE
[RHDHPAI-598] Bump OSE Tools Image

### DIFF
--- a/chart/templates/developer-hub/includes/_configure.tpl
+++ b/chart/templates/developer-hub/includes/_configure.tpl
@@ -1,7 +1,7 @@
 {{ define "rhdh.developer-hub.configure" }}
 {{ if (index .Values "developer-hub") }}
 - name: configure-developer-hub
-  image: "registry.redhat.io/openshift4/ose-tools-rhel8:latest"
+  image: "registry.redhat.io/openshift4/ose-tools-rhel9:v4.18.0-202502260503.p0.geb9bc9b.assembly.stream.el9"
   workingDir: /tmp
   command:
     - /bin/sh

--- a/chart/templates/developer-hub/includes/_configure.tpl
+++ b/chart/templates/developer-hub/includes/_configure.tpl
@@ -18,8 +18,7 @@
       CRD="backstages"
       echo -n "* Waiting for '$CRD' CRD: "
       while [ $(kubectl api-resources | grep -c "^$CRD ") = "0" ] ; do
-        echo -n "_"
-        sleep 3
+        echo -n "." && sleep 3
       done
       echo "OK"
 
@@ -52,8 +51,7 @@
       echo -n "* Waiting for RHDH route: "
       BACKSTAGE_CR_NAME="$(yq '.metadata.name' $BACKSTAGE_CR_DATA)"
       until kubectl get route -n "$NAMESPACE" "backstage-${BACKSTAGE_CR_NAME}" >/dev/null 2>&1; do
-        echo -n "_"
-        sleep 2
+        echo -n "." && sleep 3
       done
       echo "OK"
 

--- a/chart/templates/developer-hub/includes/_unconfigure.tpl
+++ b/chart/templates/developer-hub/includes/_unconfigure.tpl
@@ -1,7 +1,7 @@
 {{ define "rhdh.developer-hub.unconfigure" }}
 {{ if (index .Values "developer-hub") }}
 - name: unconfigure-developer-hub
-  image: "registry.redhat.io/openshift4/ose-tools-rhel8:latest"
+  image: "registry.redhat.io/openshift4/ose-tools-rhel9:v4.18.0-202502260503.p0.geb9bc9b.assembly.stream.el9"
   workingDir: /tmp
   command:
     - /bin/sh

--- a/chart/templates/openshift-gitops/includes/_configure.tpl
+++ b/chart/templates/openshift-gitops/includes/_configure.tpl
@@ -18,8 +18,7 @@
       CRD="argocds"
       echo "* Waiting for '$CRD' CRD *"
       while [ $(kubectl api-resources | grep -c "^$CRD ") = "0" ] ; do
-        echo -n "."
-        sleep 3
+        echo -n "." && sleep 3
       done
       echo "OK"
 
@@ -98,9 +97,8 @@
             fi
             {{- end }}
              
-            echo -n "."
             RETRY=$((RETRY + 1))
-            sleep 5
+            echo -n "." && sleep 5
           done
 
           if [[ "$RETRY" -eq "$MAX_RETRY" ]]; then
@@ -121,9 +119,8 @@
                 break
               fi
 
-              echo -n "."
               deadline_exceeded_tries=$((deadline_exceeded_tries + 1))
-              sleep 5
+              echo -n "." && sleep 5
             done
           fi
 

--- a/chart/templates/openshift-gitops/includes/_configure.tpl
+++ b/chart/templates/openshift-gitops/includes/_configure.tpl
@@ -1,6 +1,6 @@
 {{ define "rhdh.gitops.configure" }}
 - name: configure-gitops
-  image: "registry.redhat.io/openshift4/ose-tools-rhel8:latest"
+  image: "registry.redhat.io/openshift4/ose-tools-rhel9:v4.18.0-202502260503.p0.geb9bc9b.assembly.stream.el9"
   workingDir: /tmp
   command:
     - /bin/sh

--- a/chart/templates/openshift-gitops/includes/_unconfigure.tpl
+++ b/chart/templates/openshift-gitops/includes/_unconfigure.tpl
@@ -1,6 +1,6 @@
 {{ define "rhdh.gitops.unconfigure" }}
 - name: unconfigure-gitops
-  image: "registry.redhat.io/openshift4/ose-tools-rhel8:latest"
+  image: "registry.redhat.io/openshift4/ose-tools-rhel9:v4.18.0-202502260503.p0.geb9bc9b.assembly.stream.el9"
   workingDir: /tmp
   command:
     - /bin/sh

--- a/chart/templates/openshift-pipelines/includes/_configure.tpl
+++ b/chart/templates/openshift-pipelines/includes/_configure.tpl
@@ -31,8 +31,7 @@
         fi
       done
       until kubectl get route -n "$PIPELINES_NAMESPACE" pipelines-as-code-controller >/dev/null 2>&1; do
-        echo -n "."
-        sleep 3
+        echo -n "." && sleep 3
       done
       echo "OK"
 

--- a/chart/templates/openshift-pipelines/includes/_configure.tpl
+++ b/chart/templates/openshift-pipelines/includes/_configure.tpl
@@ -1,6 +1,6 @@
 {{ define "rhdh.pipelines.configure" }}
 - name: configure-pipelines
-  image: "registry.redhat.io/openshift4/ose-tools-rhel8:latest"
+  image: "registry.redhat.io/openshift4/ose-tools-rhel9:v4.18.0-202502260503.p0.geb9bc9b.assembly.stream.el9"
   workingDir: /tmp
   command:
     - /bin/bash

--- a/chart/templates/openshift-pipelines/includes/_configure.tpl
+++ b/chart/templates/openshift-pipelines/includes/_configure.tpl
@@ -21,9 +21,14 @@
       PIPELINES_NAMESPACE="openshift-pipelines"
 
       echo -n "* Waiting for pipelines operator deployment: "
-      until kubectl get namespace "$PIPELINES_NAMESPACE" >/dev/null 2>&1; do
-        echo -n "."
-        sleep 3
+      while true; do
+        kubectl wait --for=jsonpath='{.status.phase}'=Active namespace "$PIPELINES_NAMESPACE" > /dev/null 2>&1
+        if [ $? -ne 0 ]; then
+          echo -n "." && sleep 3
+        else
+          echo "OK"
+          break
+        fi
       done
       until kubectl get route -n "$PIPELINES_NAMESPACE" pipelines-as-code-controller >/dev/null 2>&1; do
         echo -n "."

--- a/chart/templates/unconfigure.yaml
+++ b/chart/templates/unconfigure.yaml
@@ -13,7 +13,6 @@ metadata:
     # job is considered part of the release.
     "helm.sh/hook": pre-delete
     "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
-
 spec:
   template:
     metadata:

--- a/resources/dev-setup-task.yaml
+++ b/resources/dev-setup-task.yaml
@@ -36,6 +36,6 @@ spec:
         value: $(params.pipelines_webhook_secret)
       - name: QUAY_DOCKERCONFIGJSON
         value: $(params.quay_dockerconfigjson)
-      image: "registry.redhat.io/openshift4/ose-tools-rhel8:latest"
+      image: "registry.redhat.io/openshift4/ose-tools-rhel9:v4.18.0-202502260503.p0.geb9bc9b.assembly.stream.el9"
       name: setup
       script: ''


### PR DESCRIPTION
### What does this PR do?:
<!-- _Summarize the changes_ -->

This PR contains the following changes:
- Bumps ose-tools to `rhel9` version `v.18`, this should provide support for up to OCP v4.18 without issue, and was tested on ocp v4.16 to maintain consistency with the docs.
- Updates `until kubectl get ...` logic with `kubectl wait` for appropriate resources.
  - `until kubectl get route ...` logic was kept in place as currently `kubectl wait` does not properly interact with Routes as they sit ontop of Ingresses and can be inconsistent.
- Refactored some pieces to ensure consistency throughout the configure templates.

### Which issue(s) this PR fixes:
<!-- _Link to Github/JIRA issue(s)_ -->
https://issues.redhat.com/browse/RHDHPAI-598

### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened and linked to this PR, if they are not in the PR scope due to various constraints.

- [x] Tested and Verified

  <!-- _I have verified that the changes were tested manually_ -->

- [ ] Documentation (READMEs, Product Docs, Blogs, Education Modules, etc.)

   <!-- _This includes READMEs, Product Docs, Blogs, Education Modules, etc._ -->


### How to test changes / Special notes to the reviewer:
Install like normal and observe expected functionality of the installer + template deployment